### PR TITLE
Bug Fix / Getters for sciences

### DIFF
--- a/src/communication/RoverCommunication.java
+++ b/src/communication/RoverCommunication.java
@@ -167,4 +167,36 @@ public class RoverCommunication implements Detector {
     public void shareScience(List<Group> groupList, Coord coord) {
         sender.shareScience(groupList, coord);
     }
+    
+    /** @return A list of science that THIS ROVER discovered */
+    public List<Coord> getMyDiscoveredSciences() {
+        return discoveredSciences;
+    }
+
+    /** @return A list of ALL "gather able" discovered sciences, science that
+     *         are not on ignored terrains (terrain THIS rover cannot
+     *         traverse) */
+    public List<Coord> getAllGatherableDiscoveredSciences() {
+
+        /* List of discovered science THIS rover can gather */
+        List<Coord> all = new ArrayList<Coord>();
+
+        /* The science THIS rover discovered may not be gathered by THIS rover
+         * Any science that is on the ignoredTerrains list will be omitted */
+        for (Coord coord : discoveredSciences) {
+            if (!receiver.getIgnoredTerrains().contains(coord.terrain)) {
+                all.add(coord);
+            }
+        }
+
+        /* Add science that other ROVERS discovered that this ROVER hasn't. By
+         * default, share science are filtered by ignored terrains. */
+        for (Coord coord : getShareScience()) {
+            if (!all.contains(coord)) {
+                all.add(coord);
+            }
+        }
+
+        return all;
+    }
 }

--- a/src/swarmBots/ROVER_01.java
+++ b/src/swarmBots/ROVER_01.java
@@ -488,6 +488,7 @@ public class ROVER_01 {
 				
 				
                 /* ********* Detect and Share Science ***************/
+				doScan();
                 rocom.detectAndShare(scanMap.getScanMap(), currentLoc, 3);
                 /* *************************************************/
 				


### PR DESCRIPTION
Rover will discovering duplicates sciences due to currentLOC and scanMap() inconsistency.

Also add some getthers  for sciences.
Call rocom.getAllGatherableDiscoveredScicnes() to get a list of coords that your rover can gather
